### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,8 @@
 name: Pygame CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/selkij/ClashLoyale/security/code-scanning/1](https://github.com/selkij/ClashLoyale/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes for the `GITHUB_TOKEN`. For a typical read-only CI workflow that just checks out code and runs tests, `contents: read` is sufficient. This block can be placed at the top level of the workflow (applying to all jobs) or under a specific job.

For this workflow, the safest and simplest change without altering functionality is to add a root-level `permissions` block right after the `name` and before `on:`. The workflow performs read-only operations (checkout, caching, installing dependencies, running tests) and does not interact with issues, PRs, or releases, so `contents: read` is appropriate. No imports or additional methods are needed since this is YAML configuration only.

Concretely:
- Edit `.github/workflows/python-app.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 2 (the blank line after `name: Pygame CI`) and line 3 (`on:`). This will restrict the `GITHUB_TOKEN` to read-only repository contents for all jobs that do not override permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
